### PR TITLE
Fix crash when updating SNR

### DIFF
--- a/horusgui/gui.py
+++ b/horusgui/gui.py
@@ -737,7 +737,11 @@ def handle_new_packet(frame):
             if widgets["horusUploadSelector"].isChecked():
                 _udp_port = int(widgets["horusUDPEntry"].text())
                 # Add in SNR data
-                _snr = float(widgets["snrLabel"].text())
+                try:
+                    _snr = float(widgets["snrLabel"].text())
+                except ValueError as e:
+                    logging.error(e)
+                    _snr = 0
                 _decoded['snr'] = _snr
 
                 send_payload_summary(_decoded, port=_udp_port)


### PR DESCRIPTION
Sometimes I get this crash when decoding a packet. It is the first
packet after starting the decoder:

2021-01-30 18:54:56,944 INFO: Started Audio Processing.
Traceback (most recent call last):
  File "horus-gui/horusgui/audio.py", line 128, in handle_samples
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyqtgraph/graphicsItems/GraphicsItem.py", line 545, in viewRangeChanged
    _stats = self.modem.add_samples(data)
  File "horus-gui/horusdemodlib/horusdemodlib/demod.py", line 362, in add_samples
    self.callback(_frame)
  File "horus-gui/horusgui/gui.py", line 750, in handle_new_packet
    def viewRangeChanged(self):
ValueError
    _snr = float(widgets["snrLabel"].text())
ValueError: could not convert string to float: '--.-'