### PR TITLE
Attempt at supporting older CPUs by using a numpy version below 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "PyQt6",
     "audioop-lts; python_version>='3.13'",
     "horusdemodlib>=0.6.1",
-    "numpy",
+    "numpy<2.4.0",
     "pyaudio",
     "pyqtgraph",
     "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2.4.0
 pyaudio
 PyQt6
 pyqtgraph


### PR DESCRIPTION
Test PR to see if reverting to numpy 2.3.x works, and works on some users with older CPUs. 
By just allowing the latest numpy version (2.4.x), this PR https://github.com/numpy/numpy/pull/28896 has meant that support is dropped for CPUs older than 2009.
... which is quite old, but there are still some users running boxes like this for Horus Binary reception.